### PR TITLE
Fix use reduce instead of flat

### DIFF
--- a/src/getTypeCheckDiagnostics.ts
+++ b/src/getTypeCheckDiagnostics.ts
@@ -13,7 +13,7 @@ export function getTypeCheckDiagnostics(
       const { diagnostics } = visitSource(checker, typeRegExpChecker, source)
       return diagnostics
     })
-    .flat()
+    .reduce((acc, val) => acc.concat(val), [])
   return {
     allDiagnostics
   }


### PR DESCRIPTION
Hi, intresting project 👍 

In Node v10.x raised following error.

```
$ ls src 
foo.ts   index.ts
$ cat src/index.ts 
const foo: number = 1
console.log(foo);

$ cat src/foo.ts
export type Props = {
  foo: number
}
```

When I ran wordcop.
```
$ wordcop
/tmp/wordcop_tests/src/index.ts:1:7 👮‍♂️ <  /.*(count|size|length)$/i
/tmp/wordcop_tests/node_modules/wordcop/dist/getTypeCheckDiagnostics.js:12
        .flat();
         ^
```

I think flat() can use Node v11.0.0.

In Node v12.0.x
```
$ npx wordcop                                             
/tmp/wordcop_tests/src/index.ts:1:7 👮‍♂️ <  /. *(count|size|length)$/i                                                         
🚨 wordcop: Error! Found violation.🚨 
```
Works fine.
So I change `flat()` to `reduce()`

I think wordcop requires Node v12 is OK.
If Node v12 required, I'll send another PR(fix README.md)

Thank you.